### PR TITLE
Fix CPiA formula definition in end-to-end example

### DIFF
--- a/examples/end_to_end_example.ipynb
+++ b/examples/end_to_end_example.ipynb
@@ -1049,7 +1049,7 @@
         "The first marketing objective we will look at is minimising the cost per incremental acquisition (where in this case an acquisition is a conversion). This means that we want to spend the least possible per incremental conversion we get. The CPiA is defined as:\n",
         "\n",
         "$$\n",
-        "\\text{CPiA} = \\frac{N_{\\text{convert}, \\, T=1} - N_{\\text{convert}, \\, T=0}}{\\text{Cost}_{T=1}}\n",
+        "\\text{CPiA} = \\frac{\\text{Cost}_{T=1}}{N_{\\text{convert}, \\, T=1} - N_{\\text{convert}, \\, T=0}}\n",
         "$$"
       ]
     },


### PR DESCRIPTION
This PR fixes the CPiA formula in the markdown of the end-to-end example notebook.

The formula was inverted, while CPiA should be defined as cost per incremental acquisition
(cost / incremental conversions).

The evaluator implementation already uses the correct definition; this change aligns the
documentation with the existing code.

No code logic or outputs were changed.